### PR TITLE
Fixes Stool Directions

### DIFF
--- a/code/game/objects/structures/beds_chairs/chair.dm
+++ b/code/game/objects/structures/beds_chairs/chair.dm
@@ -261,18 +261,18 @@
 	item_chair = /obj/item/chair/stool
 
 /obj/structure/chair/stool/directional/north
-	dir = SOUTH
-	pixel_y = 6
-
-/obj/structure/chair/stool/directional/south
 	dir = NORTH
 	pixel_y = 6
 
+/obj/structure/chair/stool/directional/south
+	dir = SOUTH
+	pixel_y = 6
+
 /obj/structure/chair/stool/directional/east
-	dir = WEST
+	dir = EAST
 
 /obj/structure/chair/stool/directional/west
-	dir = EAST
+	dir = WEST
 
 /obj/structure/chair/stool/narsie_act()
 	return
@@ -301,16 +301,16 @@
 	item_chair = /obj/item/chair/stool/bar
 
 /obj/structure/chair/stool/bar/directional/north
-	dir = SOUTH
-
-/obj/structure/chair/stool/bar/directional/south
 	dir = NORTH
 
+/obj/structure/chair/stool/bar/directional/south
+	dir = SOUTH
+
 /obj/structure/chair/stool/bar/directional/east
-	dir = WEST
+	dir = EAST
 
 /obj/structure/chair/stool/bar/directional/west
-	dir = EAST
+	dir = WEST
 
 /obj/item/chair
 	name = "chair"


### PR DESCRIPTION
Yep. Really.

## Changelog
:cl:
fix: Stools now face the right way.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
