### PR TITLE
Fixes Holestation Cargo Shuttle

### DIFF
--- a/code/modules/map_content/holestation_define.dm
+++ b/code/modules/map_content/holestation_define.dm
@@ -19,6 +19,12 @@
 	minetype = "lavaland"
 
 	allow_custom_shuttles = TRUE
+	shuttles = list(
+		"cargo" = "cargo_holestation",
+		"ferry" = "ferry_fancy",
+		"whiteship" = "whiteship_delta",
+		"emergency" = "emergency_delta",
+	)
 
 	overmap_object_type = /datum/overmap_object/shuttle/ship/holemaker
 


### PR DESCRIPTION
OOPS

## Changelog
:cl:
fix: Holestation's cargo shuttle works. Yep. Really.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
