### PR TITLE
Fixes Planetary AtmosDiffs

### DIFF
--- a/_maps/RandomRuins/Planet/abandoned_containment.dmm
+++ b/_maps/RandomRuins/Planet/abandoned_containment.dmm
@@ -350,7 +350,9 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/rust,
+/turf/open/floor/plating/rust{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/template_noop)
 "AA" = (
 /obj/structure/bed/maint,
@@ -677,7 +679,9 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/rust,
+/turf/open/floor/plating/rust{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/template_noop)
 "SO" = (
 /obj/structure/closet,

--- a/_maps/RandomRuins/Planet/abandoned_factory.dmm
+++ b/_maps/RandomRuins/Planet/abandoned_factory.dmm
@@ -7,12 +7,16 @@
 /obj/item/stack/sheet/mineral/plasma/five,
 /obj/item/wrench/caravan,
 /obj/machinery/light/small/red/directional/east,
-/turf/open/floor/plating/rust,
+/turf/open/floor/plating/rust{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered)
 "bc" = (
 /obj/effect/decal/cleanable/generic,
 /obj/effect/decal/cleanable/oil/slippery,
-/turf/open/floor/plating/rust,
+/turf/open/floor/plating/rust{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered)
 "bl" = (
 /obj/structure/fence/door{
@@ -20,13 +24,13 @@
 	open = 1
 	},
 /obj/effect/spawner/clear,
-/turf/open/floor/planetary/concrete/reinforced,
+/turf/template_noop,
 /area/template_noop)
 "bn" = (
 /obj/structure/fence/door,
 /obj/structure/barricade/wooden/crude,
 /obj/effect/spawner/clear,
-/turf/open/floor/planetary/concrete/reinforced,
+/turf/template_noop,
 /area/template_noop)
 "bw" = (
 /obj/structure/fence/corner{
@@ -43,17 +47,14 @@
 	dir = 8;
 	open = 1
 	},
-/turf/open/floor/iron/smooth_large,
+/turf/open/floor/iron/smooth_large{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered)
 "bE" = (
 /obj/structure/fence,
 /obj/effect/spawner/clear,
 /turf/template_noop,
-/area/template_noop)
-"bZ" = (
-/obj/structure/fence,
-/obj/effect/spawner/clear,
-/turf/open/floor/planetary/concrete,
 /area/template_noop)
 "cD" = (
 /obj/structure/grille,
@@ -62,7 +63,9 @@
 /obj/machinery/door/poddoor/shutters{
 	id = "abandoned_factory_window_shutters"
 	},
-/turf/open/floor/plating/rust,
+/turf/open/floor/plating/rust{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered)
 "cP" = (
 /obj/structure/safe,
@@ -82,7 +85,9 @@
 	pixel_y = 21
 	},
 /obj/effect/decal/cleanable/oil,
-/turf/open/floor/iron/smooth_large,
+/turf/open/floor/iron/smooth_large{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered)
 "dl" = (
 /obj/effect/decal/remains/human,
@@ -108,7 +113,9 @@
 /area/ruin/unpowered)
 "dD" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/smooth_large,
+/turf/open/floor/iron/smooth_large{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered)
 "dG" = (
 /obj/structure/filingcabinet,
@@ -140,19 +147,25 @@
 /area/ruin/unpowered)
 "ew" = (
 /obj/machinery/autolathe,
-/turf/open/floor/iron/smooth_large,
+/turf/open/floor/iron/smooth_large{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered)
 "eK" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/smooth_large,
+/turf/open/floor/iron/smooth_large{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered)
 "fg" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/oil,
-/turf/open/floor/iron/smooth_large,
+/turf/open/floor/iron/smooth_large{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered)
 "fo" = (
 /obj/effect/decal/cleanable/blood/old{
@@ -170,7 +183,9 @@
 /obj/structure/sink{
 	pixel_y = 20
 	},
-/turf/open/floor/plating/rust,
+/turf/open/floor/plating/rust{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered)
 "fy" = (
 /obj/structure/bed/maint{
@@ -178,19 +193,19 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/food_packaging,
-/turf/open/floor/plating/rust,
+/turf/open/floor/plating/rust{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered)
-"fV" = (
-/obj/effect/spawner/clear,
-/turf/open/floor/planetary/concrete,
-/area/template_noop)
 "gb" = (
 /obj/structure/bed/maint{
 	pixel_y = 6
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/prison_contraband,
-/turf/open/floor/iron/smooth_large,
+/turf/open/floor/iron/smooth_large{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered)
 "gg" = (
 /obj/structure/bed/maint{
@@ -198,7 +213,9 @@
 	},
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/smooth_large,
+/turf/open/floor/iron/smooth_large{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered)
 "gh" = (
 /obj/structure/cable,
@@ -209,7 +226,9 @@
 /obj/item/stack/conveyor,
 /obj/item/stack/conveyor,
 /obj/structure/rack,
-/turf/open/floor/plating/rust,
+/turf/open/floor/plating/rust{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered)
 "gV" = (
 /obj/structure/bed/maint{
@@ -218,14 +237,18 @@
 /obj/effect/decal/cleanable/generic,
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/plating/rust,
+/turf/open/floor/plating/rust{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered)
 "hR" = (
 /obj/machinery/shower{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/rust,
+/turf/open/floor/plating/rust{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered)
 "if" = (
 /obj/item/trash/can{
@@ -242,7 +265,9 @@
 /obj/effect/decal/cleanable/vomit/old,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/food_packaging,
-/turf/open/floor/iron/smooth_large,
+/turf/open/floor/iron/smooth_large{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered)
 "iE" = (
 /obj/structure/table/greyscale,
@@ -250,7 +275,9 @@
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/effect/spawner/lootdrop/food_packaging,
 /obj/effect/spawner/lootdrop/food_packaging,
-/turf/open/floor/iron/smooth_large,
+/turf/open/floor/iron/smooth_large{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered)
 "js" = (
 /obj/structure/chair/greyscale{
@@ -258,21 +285,22 @@
 	},
 /obj/machinery/light/small/broken/directional/north,
 /obj/effect/decal/cleanable/oil/slippery,
-/turf/open/floor/plating/rust,
+/turf/open/floor/plating/rust{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered)
 "ju" = (
 /obj/effect/decal/cleanable/oil,
-/turf/open/floor/plating/rust,
+/turf/open/floor/plating/rust{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered)
-"kL" = (
-/obj/structure/fence,
-/obj/effect/spawner/clear,
-/turf/open/floor/planetary/concrete/reinforced,
-/area/template_noop)
 "la" = (
 /obj/effect/turf_decal/caution/stand_clear/red,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/smooth_large,
+/turf/open/floor/iron/smooth_large{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered)
 "lg" = (
 /obj/structure/closet/crate,
@@ -286,7 +314,8 @@
 /obj/effect/spawner/lootdrop/away_loot,
 /obj/machinery/light/small/red/directional/north,
 /turf/open/floor/iron/smooth_corner{
-	dir = 8
+	dir = 8;
+	initial_gas_mix = "PLANETARY_ATMOS"
 	},
 /area/ruin/unpowered)
 "lA" = (
@@ -294,18 +323,24 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/turf/open/floor/iron/smooth_large,
+/turf/open/floor/iron/smooth_large{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered)
 "lC" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/table_frame,
-/turf/open/floor/iron/smooth_large,
+/turf/open/floor/iron/smooth_large{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered)
 "lU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/structure/fence,
-/turf/open/floor/iron/smooth_half,
+/turf/open/floor/iron/smooth_half{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered)
 "mh" = (
 /obj/machinery/conveyor{
@@ -317,7 +352,9 @@
 /obj/structure/sign/poster/official/obey{
 	pixel_y = 32
 	},
-/turf/open/floor/iron/smooth_large,
+/turf/open/floor/iron/smooth_large{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered)
 "mC" = (
 /obj/structure/closet/cabinet,
@@ -330,7 +367,9 @@
 /obj/structure/fence/cut/medium{
 	dir = 8
 	},
-/turf/open/floor/plating/rust,
+/turf/open/floor/plating/rust{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered)
 "nI" = (
 /turf/template_noop,
@@ -339,7 +378,9 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
-/turf/open/floor/iron/smooth_large,
+/turf/open/floor/iron/smooth_large{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered)
 "oV" = (
 /obj/effect/decal/cleanable/blood/footprints{
@@ -366,7 +407,9 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/spawner/lootdrop/tool,
 /obj/structure/table,
-/turf/open/floor/iron/smooth_large,
+/turf/open/floor/iron/smooth_large{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered)
 "ph" = (
 /obj/structure/table/wood,
@@ -398,13 +441,17 @@
 /area/ruin/unpowered)
 "pr" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/rust,
+/turf/open/floor/plating/rust{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered)
 "pt" = (
 /obj/structure/frame{
 	anchored = 1
 	},
-/turf/open/floor/plating/rust,
+/turf/open/floor/plating/rust{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered)
 "pK" = (
 /obj/structure/pitgrate,
@@ -421,16 +468,22 @@
 /obj/structure/sign/poster/ripped{
 	pixel_y = 32
 	},
-/turf/open/floor/iron/smooth_large,
+/turf/open/floor/iron/smooth_large{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered)
 "qm" = (
 /obj/machinery/door/airlock/maintenance_hatch,
-/turf/open/floor/plating/rust,
+/turf/open/floor/plating/rust{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered)
 "qn" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/plating/rust,
+/turf/open/floor/plating/rust{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered)
 "qF" = (
 /obj/effect/decal/cleanable/generic{
@@ -443,7 +496,9 @@
 	projectile_type = null
 	},
 /obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/plating/rust,
+/turf/open/floor/plating/rust{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered)
 "qG" = (
 /obj/structure/pitgrate,
@@ -457,17 +512,23 @@
 /obj/effect/decal/cleanable/generic,
 /obj/effect/spawner/lootdrop/tool,
 /obj/structure/table,
-/turf/open/floor/iron/smooth_large,
+/turf/open/floor/iron/smooth_large{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered)
 "rh" = (
 /obj/structure/fence,
 /obj/effect/decal/cleanable/oil/slippery,
-/turf/open/floor/iron/smooth_large,
+/turf/open/floor/iron/smooth_large{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered)
 "rA" = (
 /obj/effect/turf_decal/weather,
 /obj/structure/rubble/large,
-/turf/open/floor/plating/rust,
+/turf/open/floor/plating/rust{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered)
 "sO" = (
 /obj/machinery/conveyor{
@@ -477,7 +538,9 @@
 /obj/structure/sign/poster/ripped{
 	pixel_y = 32
 	},
-/turf/open/floor/iron/smooth_large,
+/turf/open/floor/iron/smooth_large{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered)
 "tX" = (
 /obj/item/ammo_casing/c45{
@@ -508,7 +571,9 @@
 	},
 /obj/effect/decal/cleanable/blood/footprints,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/smooth_large,
+/turf/open/floor/iron/smooth_large{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered)
 "uh" = (
 /obj/effect/decal/remains/human{
@@ -520,7 +585,9 @@
 	pixel_y = 18
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/smooth_large,
+/turf/open/floor/iron/smooth_large{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered)
 "us" = (
 /obj/effect/spawner/clear,
@@ -530,7 +597,9 @@
 /obj/structure/frame/computer{
 	anchored = 1
 	},
-/turf/open/floor/iron/smooth_large,
+/turf/open/floor/iron/smooth_large{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered)
 "uU" = (
 /obj/structure/fence{
@@ -547,44 +616,52 @@
 	},
 /obj/item/stack/rods,
 /obj/item/stack/sheet/iron/ten,
-/turf/open/floor/iron/smooth_large,
+/turf/open/floor/iron/smooth_large{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered)
 "vw" = (
 /obj/item/chair/stool,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/food_packaging,
-/turf/open/floor/iron/smooth_large,
+/turf/open/floor/iron/smooth_large{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered)
-"vB" = (
-/obj/effect/spawner/clear,
-/turf/open/floor/planetary/concrete/reinforced,
-/area/template_noop)
 "vK" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/directional/east,
-/turf/open/floor/iron/smooth_large,
+/turf/open/floor/iron/smooth_large{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered)
 "vL" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "abandoned_factory_north_shutters"
 	},
-/turf/open/floor/plating/rust,
+/turf/open/floor/plating/rust{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered)
 "vS" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/table,
 /obj/item/stack/sheet/iron/ten,
-/turf/open/floor/iron/smooth_large,
+/turf/open/floor/iron/smooth_large{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered)
 "wX" = (
 /obj/structure/table/greyscale,
 /obj/effect/spawner/lootdrop/food_packaging,
 /obj/machinery/light/small/directional/east,
-/turf/open/floor/iron/smooth_large,
+/turf/open/floor/iron/smooth_large{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered)
 "xl" = (
 /obj/effect/spawner/clear,
@@ -605,12 +682,16 @@
 /obj/structure/chair/greyscale{
 	dir = 4
 	},
-/turf/open/floor/plating/rust,
+/turf/open/floor/plating/rust{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered)
 "xM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/gross_decal_spawner,
-/turf/open/floor/iron/smooth_large,
+/turf/open/floor/iron/smooth_large{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered)
 "yh" = (
 /obj/effect/decal/cleanable/dirt,
@@ -620,7 +701,8 @@
 	pixel_x = -32
 	},
 /turf/open/floor/iron/smooth_half{
-	dir = 1
+	dir = 1;
+	initial_gas_mix = "PLANETARY_ATMOS"
 	},
 /area/ruin/unpowered)
 "yu" = (
@@ -632,12 +714,16 @@
 /obj/structure/barricade/wooden/crude{
 	layer = 3.2
 	},
-/turf/open/floor/plating/rust,
+/turf/open/floor/plating/rust{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered)
 "zX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/generic,
-/turf/open/floor/iron/smooth_large,
+/turf/open/floor/iron/smooth_large{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered)
 "Ar" = (
 /obj/structure/fence/corner{
@@ -651,7 +737,9 @@
 /obj/structure/fence/corner{
 	dir = 8
 	},
-/turf/open/floor/iron/smooth_large,
+/turf/open/floor/iron/smooth_large{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered)
 "BE" = (
 /obj/effect/spawner/clear,
@@ -670,7 +758,9 @@
 	anchored = 1
 	},
 /obj/effect/decal/cleanable/robot_debris/down,
-/turf/open/floor/iron/smooth_large,
+/turf/open/floor/iron/smooth_large{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered)
 "Em" = (
 /obj/structure/pitgrate,
@@ -679,22 +769,29 @@
 /area/ruin/unpowered)
 "Ep" = (
 /mob/living/simple_animal/hostile/giant_spider/hunter,
-/turf/open/floor/iron/smooth_large,
+/turf/open/floor/iron/smooth_large{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered)
 "EE" = (
 /obj/effect/turf_decal/weather,
-/turf/open/floor/plating/rust,
+/turf/open/floor/plating/rust{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered)
 "EX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/gross_decal_spawner,
 /obj/structure/cable,
-/turf/open/floor/iron/smooth_half,
+/turf/open/floor/iron/smooth_half{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered)
 "Fp" = (
 /obj/structure/closet/crate,
 /turf/open/floor/iron/smooth_half{
-	dir = 1
+	dir = 1;
+	initial_gas_mix = "PLANETARY_ATMOS"
 	},
 /area/ruin/unpowered)
 "Fw" = (
@@ -767,14 +864,18 @@
 /obj/machinery/conveyor_switch/oneway{
 	id = "abandoned_factory_conveyor"
 	},
-/turf/open/floor/iron/smooth_large,
+/turf/open/floor/iron/smooth_large{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered)
 "HQ" = (
 /obj/structure/cable,
 /obj/machinery/power/smes{
 	panel_open = 1
 	},
-/turf/open/floor/plating/rust,
+/turf/open/floor/plating/rust{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered)
 "HS" = (
 /obj/machinery/door/airlock/maintenance_hatch,
@@ -782,7 +883,9 @@
 /obj/structure/barricade/wooden/crude{
 	layer = 3.2
 	},
-/turf/open/floor/plating/rust,
+/turf/open/floor/plating/rust{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered)
 "Il" = (
 /obj/effect/decal/cleanable/wrapping{
@@ -790,22 +893,29 @@
 	},
 /obj/structure/spider/stickyweb,
 /turf/open/floor/iron/smooth_half{
-	dir = 1
+	dir = 1;
+	initial_gas_mix = "PLANETARY_ATMOS"
 	},
 /area/ruin/unpowered)
 "Iq" = (
 /obj/structure/cable,
-/turf/open/floor/iron/smooth_half,
+/turf/open/floor/iron/smooth_half{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered)
 "IQ" = (
 /obj/effect/decal/cleanable/wrapping{
 	pixel_x = -13;
 	pixel_y = 20
 	},
-/turf/open/floor/iron/smooth_large,
+/turf/open/floor/iron/smooth_large{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered)
 "Jd" = (
-/turf/open/floor/iron/smooth_large,
+/turf/open/floor/iron/smooth_large{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered)
 "JC" = (
 /obj/effect/turf_decal/box/corners,
@@ -815,7 +925,8 @@
 /obj/item/chair,
 /obj/structure/rack,
 /turf/open/floor/iron/smooth_half{
-	dir = 1
+	dir = 1;
+	initial_gas_mix = "PLANETARY_ATMOS"
 	},
 /area/ruin/unpowered)
 "JL" = (
@@ -829,7 +940,9 @@
 /obj/machinery/conveyor_switch/oneway{
 	id = "abandoned_factory_conveyor"
 	},
-/turf/open/floor/iron/smooth_large,
+/turf/open/floor/iron/smooth_large{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered)
 "Ke" = (
 /obj/effect/decal/cleanable/blood/footprints{
@@ -844,12 +957,16 @@
 /obj/structure/barricade/wooden/crude{
 	layer = 3.2
 	},
-/turf/open/floor/plating/rust,
+/turf/open/floor/plating/rust{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered)
 "Ki" = (
 /obj/structure/closet/crate/trashcart,
 /obj/effect/decal/cleanable/cobweb,
-/turf/open/floor/iron/smooth_corner,
+/turf/open/floor/iron/smooth_corner{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered)
 "KM" = (
 /obj/structure/pitgrate,
@@ -861,12 +978,16 @@
 /obj/structure/frame/computer{
 	anchored = 1
 	},
-/turf/open/floor/plating/rust,
+/turf/open/floor/plating/rust{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered)
 "La" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/turf/open/floor/plating/rust,
+/turf/open/floor/plating/rust{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered)
 "LH" = (
 /obj/effect/decal/cleanable/molten_object/large,
@@ -875,11 +996,15 @@
 /obj/structure/sign/poster/official/work_for_a_future{
 	pixel_y = 32
 	},
-/turf/open/floor/iron/smooth_half,
+/turf/open/floor/iron/smooth_half{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered)
 "LV" = (
 /obj/machinery/power/port_gen/pacman,
-/turf/open/floor/plating/rust,
+/turf/open/floor/plating/rust{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered)
 "MB" = (
 /turf/closed/wall/concrete,
@@ -890,49 +1015,58 @@
 	id = "abandoned_factory_conveyor"
 	},
 /obj/machinery/light/small/built/directional/west,
-/turf/open/floor/plating/rust,
+/turf/open/floor/plating/rust{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered)
 "MN" = (
 /obj/effect/decal/cleanable/molten_object/large,
-/turf/open/floor/iron/smooth_large,
+/turf/open/floor/iron/smooth_large{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered)
 "Nw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/stack/rods,
 /obj/effect/spawner/lootdrop/garbage_spawner,
 /obj/structure/rack,
-/turf/open/floor/iron/smooth_half,
+/turf/open/floor/iron/smooth_half{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered)
 "Ob" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/turf/open/floor/iron/smooth_half,
+/turf/open/floor/iron/smooth_half{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered)
 "Oj" = (
 /obj/machinery/vending/sovietsoda,
-/turf/open/floor/iron/smooth_half,
-/area/ruin/unpowered)
-"Oq" = (
-/obj/structure/fence{
-	dir = 8
+/turf/open/floor/iron/smooth_half{
+	initial_gas_mix = "PLANETARY_ATMOS"
 	},
-/obj/effect/spawner/clear,
-/turf/open/floor/planetary/concrete,
-/area/template_noop)
+/area/ruin/unpowered)
 "OA" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/decal/cleanable/oil/slippery,
 /obj/effect/spawner/lootdrop/tool,
 /obj/structure/table,
-/turf/open/floor/iron/smooth_large,
+/turf/open/floor/iron/smooth_large{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered)
 "OY" = (
 /obj/machinery/vending/cigarette,
-/turf/open/floor/plating/rust,
+/turf/open/floor/plating/rust{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered)
 "Po" = (
 /obj/structure/table,
-/turf/open/floor/plating/rust,
+/turf/open/floor/plating/rust{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered)
 "PU" = (
 /obj/structure/grille,
@@ -943,18 +1077,24 @@
 /obj/structure/barricade/wooden/crude{
 	layer = 3.2
 	},
-/turf/open/floor/plating/rust,
+/turf/open/floor/plating/rust{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered)
 "Qj" = (
 /obj/effect/decal/cleanable/blood/footprints,
 /obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/plating/rust,
+/turf/open/floor/plating/rust{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered)
 "Qk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/clothing/neck/stethoscope,
 /obj/effect/spawner/lootdrop/medical,
-/turf/open/floor/iron/smooth_half,
+/turf/open/floor/iron/smooth_half{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered)
 "Qu" = (
 /obj/structure/fence{
@@ -966,27 +1106,33 @@
 "QS" = (
 /obj/structure/rubble/large,
 /obj/effect/spawner/clear,
-/turf/open/floor/planetary/concrete,
+/turf/template_noop,
 /area/template_noop)
 "QV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/toolbox,
 /obj/structure/spider/stickyweb,
-/turf/open/floor/iron/smooth_half,
+/turf/open/floor/iron/smooth_half{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered)
 "Rk" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/tool,
 /obj/structure/spider/stickyweb,
-/turf/open/floor/iron/smooth_half,
+/turf/open/floor/iron/smooth_half{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered)
 "RL" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/smooth_half,
+/turf/open/floor/iron/smooth_half{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered)
 "St" = (
 /obj/structure/grille/broken,
@@ -995,49 +1141,64 @@
 /obj/machinery/door/poddoor/shutters{
 	id = "abandoned_factory_window_shutters"
 	},
-/turf/open/floor/plating/rust,
+/turf/open/floor/plating/rust{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered)
 "Sv" = (
 /obj/machinery/conveyor{
 	dir = 1;
 	id = "abandoned_factory_conveyor"
 	},
-/turf/open/floor/iron/smooth_large,
+/turf/open/floor/iron/smooth_large{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered)
 "SW" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "abandoned_factory_shutters_west"
 	},
-/turf/open/floor/plating/rust,
+/turf/open/floor/plating/rust{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered)
 "Tf" = (
 /obj/machinery/conveyor_switch/oneway{
 	id = "abandoned_factory_conveyor"
 	},
 /obj/structure/spider/stickyweb,
-/turf/open/floor/iron/smooth_large,
+/turf/open/floor/iron/smooth_large{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered)
 "To" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/table,
 /obj/item/stack/sheet/iron/twenty,
-/turf/open/floor/iron/smooth_large,
+/turf/open/floor/iron/smooth_large{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered)
 "Ty" = (
 /obj/structure/spider/stickyweb,
 /turf/open/floor/iron/smooth_half{
-	dir = 1
+	dir = 1;
+	initial_gas_mix = "PLANETARY_ATMOS"
 	},
 /area/ruin/unpowered)
 "Tz" = (
 /obj/structure/cable,
-/turf/open/floor/plating/rust,
+/turf/open/floor/plating/rust{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered)
 "TF" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/decal/cleanable/garbage,
 /obj/structure/cable,
-/turf/open/floor/iron/smooth_corner,
+/turf/open/floor/iron/smooth_corner{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered)
 "Ui" = (
 /obj/effect/decal/cleanable/blood/footprints{
@@ -1052,7 +1213,9 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/turf/open/floor/iron/smooth_half,
+/turf/open/floor/iron/smooth_half{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered)
 "Us" = (
 /obj/effect/decal/cleanable/blood/footprints{
@@ -1061,7 +1224,9 @@
 	pixel_y = 13
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/smooth_half,
+/turf/open/floor/iron/smooth_half{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered)
 "Ut" = (
 /obj/effect/decal/cleanable/blood/footprints{
@@ -1069,7 +1234,9 @@
 	pixel_x = -13;
 	pixel_y = 13
 	},
-/turf/open/floor/iron/smooth_half,
+/turf/open/floor/iron/smooth_half{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered)
 "Uz" = (
 /obj/effect/decal/cleanable/blood/footprints{
@@ -1079,7 +1246,8 @@
 	},
 /obj/effect/spawner/lootdrop/garbage_spawner,
 /turf/open/floor/iron/smooth_corner{
-	dir = 1
+	dir = 1;
+	initial_gas_mix = "PLANETARY_ATMOS"
 	},
 /area/ruin/unpowered)
 "UR" = (
@@ -1095,7 +1263,9 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/generic,
-/turf/open/floor/iron/smooth_large,
+/turf/open/floor/iron/smooth_large{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered)
 "UT" = (
 /obj/effect/decal/cleanable/blood/footprints{
@@ -1109,13 +1279,17 @@
 	pixel_y = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/smooth_large,
+/turf/open/floor/iron/smooth_large{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered)
 "Vk" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 1
 	},
-/turf/open/floor/iron/smooth_large,
+/turf/open/floor/iron/smooth_large{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered)
 "Vn" = (
 /obj/effect/decal/cleanable/blood/footprints{
@@ -1124,7 +1298,9 @@
 	pixel_y = 13
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/smooth_large,
+/turf/open/floor/iron/smooth_large{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered)
 "Vq" = (
 /obj/structure/grille,
@@ -1135,12 +1311,16 @@
 /obj/machinery/door/poddoor{
 	id = "abandoned_factory_window_shutters"
 	},
-/turf/open/floor/plating/rust,
+/turf/open/floor/plating/rust{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered)
 "VI" = (
 /obj/effect/decal/cleanable/generic,
 /obj/structure/cable,
-/turf/open/floor/plating/rust,
+/turf/open/floor/plating/rust{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered)
 "VN" = (
 /obj/structure/fence/door{
@@ -1155,7 +1335,9 @@
 	dir = 4;
 	id = "abandoned_factory_conveyor"
 	},
-/turf/open/floor/iron/smooth_large,
+/turf/open/floor/iron/smooth_large{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered)
 "Wm" = (
 /obj/effect/decal/cleanable/blood/footprints{
@@ -1173,7 +1355,9 @@
 	pixel_x = 2
 	},
 /obj/machinery/light/small/built/directional/south,
-/turf/open/floor/iron/smooth_large,
+/turf/open/floor/iron/smooth_large{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered)
 "Ww" = (
 /obj/effect/decal/cleanable/oil,
@@ -1185,7 +1369,9 @@
 /obj/item/stack/conveyor,
 /obj/item/stack/conveyor,
 /obj/item/stack/conveyor,
-/turf/open/floor/plating/rust,
+/turf/open/floor/plating/rust{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered)
 "WC" = (
 /obj/effect/decal/cleanable/blood/footprints{
@@ -1193,18 +1379,26 @@
 	pixel_x = -13;
 	pixel_y = 13
 	},
-/turf/open/floor/iron/smooth_large,
+/turf/open/floor/iron/smooth_large{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered)
 "Xf" = (
-/turf/open/floor/plating/rust,
+/turf/open/floor/plating/rust{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered)
 "Yi" = (
 /obj/effect/spawner/lootdrop/gross_decal_spawner,
-/turf/open/floor/iron/smooth_large,
+/turf/open/floor/iron/smooth_large{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered)
 "YD" = (
 /obj/structure/spider/stickyweb,
-/turf/open/floor/iron/smooth_large,
+/turf/open/floor/iron/smooth_large{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered)
 "YZ" = (
 /obj/effect/spawner/clear,
@@ -1213,11 +1407,14 @@
 "Zt" = (
 /obj/effect/spawner/lootdrop/gross_decal_spawner,
 /mob/living/simple_animal/hostile/giant_spider,
-/turf/open/floor/iron/smooth_large,
+/turf/open/floor/iron/smooth_large{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered)
 "Zv" = (
 /turf/open/floor/iron/smooth_half{
-	dir = 1
+	dir = 1;
+	initial_gas_mix = "PLANETARY_ATMOS"
 	},
 /area/ruin/unpowered)
 "ZI" = (
@@ -1225,13 +1422,15 @@
 	dir = 8
 	},
 /obj/effect/spawner/clear,
-/turf/open/floor/planetary/concrete/reinforced,
+/turf/template_noop,
 /area/template_noop)
 "ZU" = (
 /obj/machinery/door/airlock/maintenance/external{
 	locked = 1
 	},
-/turf/open/floor/plating/rust,
+/turf/open/floor/plating/rust{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered)
 "ZZ" = (
 /obj/structure/fence{
@@ -1265,7 +1464,7 @@ YZ
 nI
 Ar
 bE
-bZ
+bE
 bE
 bE
 Fw
@@ -1275,7 +1474,7 @@ ZI
 JL
 VN
 bl
-kL
+bE
 bE
 bE
 xo
@@ -1285,16 +1484,16 @@ YZ
 nI
 ZZ
 YZ
-fV
-fV
 YZ
 YZ
 YZ
 YZ
-vB
+YZ
+YZ
+YZ
 BE
-vB
-vB
+YZ
+YZ
 YZ
 YZ
 YZ
@@ -1338,7 +1537,7 @@ lA
 gh
 MB
 YZ
-Oq
+Qu
 nI
 "}
 (6,1,1) = {"
@@ -1358,7 +1557,7 @@ Xf
 Tz
 MB
 YZ
-Oq
+Qu
 nI
 "}
 (7,1,1) = {"
@@ -1377,7 +1576,7 @@ dD
 dD
 Ww
 MB
-fV
+YZ
 Qu
 nI
 "}
@@ -1637,14 +1836,14 @@ uE
 xM
 Iq
 St
-fV
+YZ
 Qu
 nI
 "}
 (21,1,1) = {"
 YZ
 bn
-vB
+YZ
 vL
 ju
 zX
@@ -1657,14 +1856,14 @@ Jd
 Yi
 Ob
 St
-fV
-Oq
+YZ
+Qu
 nI
 "}
 (22,1,1) = {"
 YZ
 bn
-vB
+YZ
 vL
 la
 Ep
@@ -1678,7 +1877,7 @@ bz
 lU
 MB
 YZ
-Oq
+Qu
 nI
 "}
 (23,1,1) = {"
@@ -1733,7 +1932,7 @@ YZ
 YZ
 YZ
 YZ
-fV
+YZ
 YZ
 YZ
 YZ

--- a/_maps/RandomRuins/Planet/crashed_pod.dmm
+++ b/_maps/RandomRuins/Planet/crashed_pod.dmm
@@ -10,7 +10,8 @@
 /obj/structure/shuttle/engine/propulsion{
 	dir = 1
 	},
-/turf/open/floor/planetary/rock,
+/obj/effect/spawner/clear,
+/turf/template_noop,
 /area/template_noop)
 "cs" = (
 /obj/item/stack/sheet/iron/ten,
@@ -32,7 +33,8 @@
 /area/ruin/unpowered/crashed_pod)
 "eg" = (
 /obj/effect/decal/remains/human/grave,
-/turf/open/floor/planetary/rock,
+/obj/effect/spawner/clear,
+/turf/template_noop,
 /area/template_noop)
 "eO" = (
 /obj/structure/table,
@@ -43,14 +45,18 @@
 "gB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table_frame,
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/mineral/titanium{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered/crashed_pod)
 "hb" = (
 /obj/item/electronics/tracker,
 /obj/item/stack/sheet/glass{
 	amount = 5
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/template_noop)
 "iA" = (
 /obj/structure/table,
@@ -64,13 +70,16 @@
 /obj/structure/shuttle/engine/propulsion{
 	dir = 4
 	},
-/turf/open/floor/planetary/concrete,
+/obj/effect/spawner/clear,
+/turf/template_noop,
 /area/template_noop)
 "jb" = (
 /obj/structure/chair/comfy/shuttle,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden,
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/mineral/titanium{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered/crashed_pod)
 "jP" = (
 /obj/effect/decal/cleanable/dirt,
@@ -98,7 +107,9 @@
 /area/ruin/unpowered/crashed_pod)
 "mi" = (
 /obj/structure/girder,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/template_noop)
 "mw" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -116,7 +127,9 @@
 /area/ruin/unpowered/crashed_pod)
 "nq" = (
 /obj/structure/girder,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered/crashed_pod)
 "nN" = (
 /obj/structure/cable,
@@ -155,7 +168,9 @@
 "rQ" = (
 /obj/item/stack/sheet/iron/ten,
 /obj/item/solar_assembly,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/template_noop)
 "sF" = (
 /obj/machinery/power/smes,
@@ -169,7 +184,9 @@
 /obj/structure/shuttle/engine/heater{
 	dir = 1
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/template_noop)
 "up" = (
 /obj/structure/rack,
@@ -197,7 +214,9 @@
 /area/ruin/unpowered/crashed_pod)
 "uJ" = (
 /obj/item/solar_assembly,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/template_noop)
 "vc" = (
 /obj/structure/rack,
@@ -221,7 +240,9 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/cash,
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/mineral/titanium{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered/crashed_pod)
 "vp" = (
 /obj/effect/decal/cleanable/dirt,
@@ -240,7 +261,9 @@
 /obj/effect/spawner/lootdrop/medicine,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/powercell,
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/mineral/titanium{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered/crashed_pod)
 "wO" = (
 /obj/structure/window/reinforced/spawner/east,
@@ -260,7 +283,9 @@
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/melee_weapon,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/mineral/titanium{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered/crashed_pod)
 "xr" = (
 /obj/item/storage/toolbox/emergency,
@@ -286,12 +311,16 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/mineral/titanium{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered/crashed_pod)
 "zV" = (
 /obj/structure/cable,
 /obj/item/stack/cable_coil,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/template_noop)
 "AU" = (
 /obj/effect/spawner/lootdrop/maintenance/four,
@@ -335,12 +364,16 @@
 /turf/open/floor/mineral/titanium,
 /area/ruin/unpowered/crashed_pod)
 "ER" = (
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/template_noop)
 "EW" = (
 /obj/effect/decal/cleanable/shreds,
 /obj/effect/turf_decal/sand/plating,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/template_noop)
 "Fn" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
@@ -420,7 +453,9 @@
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden,
 /obj/structure/table_frame,
 /obj/item/bedsheet/medical,
-/turf/open/floor/mineral/titanium/white,
+/turf/open/floor/mineral/titanium/white{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/ruin/unpowered/crashed_pod)
 "NX" = (
 /obj/effect/spawner/lootdrop/maintenance,
@@ -487,7 +522,8 @@
 /turf/open/floor/mineral/titanium,
 /area/ruin/unpowered/crashed_pod)
 "RE" = (
-/turf/open/floor/planetary/concrete,
+/obj/effect/spawner/clear,
+/turf/template_noop,
 /area/template_noop)
 "RR" = (
 /turf/template_noop,
@@ -528,8 +564,10 @@
 "UM" = (
 /obj/structure/bed/pod,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/ruin/unpowered/crashed_pod)
+/turf/open/floor/plating{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
+/area/template_noop)
 "UN" = (
 /obj/machinery/firealarm/directional/south,
 /obj/effect/decal/cleanable/dirt,
@@ -538,7 +576,9 @@
 /turf/open/floor/mineral/titanium,
 /area/ruin/unpowered/crashed_pod)
 "UO" = (
-/turf/open/floor/plating/foam,
+/turf/open/floor/plating/foam{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/template_noop)
 "UX" = (
 /obj/structure/cable,
@@ -550,8 +590,10 @@
 /area/ruin/unpowered/crashed_pod)
 "Vj" = (
 /obj/effect/turf_decal/sand/plating,
-/turf/open/floor/plating,
-/area/template_noop)
+/turf/open/floor/plating{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
+/area/ruin/unpowered/crashed_pod)
 "Vt" = (
 /obj/effect/mapping_helpers/smart_pipe/manifold4w/supply/hidden,
 /turf/closed/wall/mineral/titanium,
@@ -602,8 +644,10 @@
 /obj/effect/spawner/lootdrop/medkit,
 /obj/effect/spawner/lootdrop/medkit,
 /obj/machinery/light/small/broken/directional/north,
-/turf/open/floor/mineral/titanium/white,
-/area/template_noop)
+/turf/open/floor/mineral/titanium/white{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
+/area/ruin/unpowered/crashed_pod)
 "XP" = (
 /obj/structure/window/reinforced/spawner/west,
 /obj/structure/chair/comfy/shuttle,
@@ -612,8 +656,10 @@
 /turf/open/floor/mineral/titanium/purple,
 /area/ruin/unpowered/crashed_pod)
 "YH" = (
-/turf/open/floor/planetary/rock,
-/area/template_noop)
+/turf/open/floor/plating{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
+/area/ruin/unpowered/crashed_pod)
 "Zl" = (
 /obj/structure/chair/stool,
 /obj/effect/decal/cleanable/dirt,
@@ -628,29 +674,29 @@
 (1,1,1) = {"
 RR
 RR
-YH
-YH
-YH
-YH
+RE
+RE
+RE
+RE
 RR
-YH
-YH
-YH
-YH
-YH
-YH
-YH
-YH
+RE
+RE
+RE
+RE
+RE
+RE
+RE
+RE
 RR
 RR
 RR
 RR
 "}
 (2,1,1) = {"
-YH
-YH
+RE
+RE
 eg
-YH
+RE
 rQ
 uJ
 mi
@@ -668,9 +714,9 @@ RR
 RR
 "}
 (3,1,1) = {"
-YH
+RE
 co
-YH
+RE
 mi
 ER
 zV
@@ -689,9 +735,9 @@ EW
 RR
 "}
 (4,1,1) = {"
-YH
-YH
-YH
+RE
+RE
+RE
 mi
 ud
 Mb
@@ -707,11 +753,11 @@ jP
 Xn
 Mr
 UM
-YH
+RE
 "}
 (5,1,1) = {"
-YH
-YH
+RE
+RE
 RE
 xA
 xA
@@ -728,10 +774,10 @@ RB
 Qu
 Qu
 Qu
-YH
+RE
 "}
 (6,1,1) = {"
-YH
+RE
 RE
 iC
 xA
@@ -770,7 +816,7 @@ jP
 yS
 jb
 zs
-JH
+YH
 "}
 (8,1,1) = {"
 RE
@@ -791,11 +837,11 @@ Vx
 Qu
 xj
 wC
-JH
+YH
 "}
 (9,1,1) = {"
-YH
-YH
+RE
+RE
 RE
 qW
 lU
@@ -815,7 +861,7 @@ Qu
 nq
 "}
 (10,1,1) = {"
-YH
+RE
 RE
 RE
 Qu
@@ -836,9 +882,9 @@ CV
 Qu
 "}
 (11,1,1) = {"
-YH
-YH
-YH
+RE
+RE
+RE
 qW
 lU
 xr
@@ -857,9 +903,9 @@ On
 Qn
 "}
 (12,1,1) = {"
-YH
-YH
-YH
+RE
+RE
+RE
 Qu
 Qu
 Fn
@@ -879,9 +925,9 @@ Qu
 "}
 (13,1,1) = {"
 RR
-YH
-YH
-YH
+RE
+RE
+RE
 Qu
 Qu
 Qu
@@ -901,21 +947,21 @@ Qu
 (14,1,1) = {"
 RR
 RR
-YH
-YH
-YH
-YH
-YH
-YH
-YH
-YH
-YH
-YH
+RE
+RE
+RE
+RE
+RE
+RE
+RE
+RE
+RE
+RE
 RR
 RR
 RR
-YH
-YH
+RE
+RE
 RR
 RR
 "}

--- a/_maps/RandomRuins/Planet/lodge.dmm
+++ b/_maps/RandomRuins/Planet/lodge.dmm
@@ -28,7 +28,9 @@
 /area/ruin/unpowered)
 "dN" = (
 /obj/structure/mineral_door/wood,
-/turf/template_noop,
+/turf/open/floor/wood{
+	icon_state = "wood-broken5"
+	},
 /area/ruin/unpowered)
 "dZ" = (
 /obj/structure/reagent_dispensers/watertank,

--- a/_maps/RandomRuins/Planet/mining_facility.dmm
+++ b/_maps/RandomRuins/Planet/mining_facility.dmm
@@ -21,6 +21,15 @@
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/plating,
 /area/ruin/unpowered)
+"cZ" = (
+/obj/machinery/conveyor{
+	id = "mining_facil"
+	},
+/obj/machinery/light/warm/directional/west,
+/turf/open/floor/plating{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
+/area/ruin/unpowered)
 "gr" = (
 /obj/machinery/door/airlock/mining,
 /turf/open/floor/plating,
@@ -463,7 +472,7 @@ OG
 Zw
 uH
 uH
-xM
+cZ
 nH
 lO
 xM

--- a/_maps/RandomRuins/Planet/weather_station.dmm
+++ b/_maps/RandomRuins/Planet/weather_station.dmm
@@ -16,7 +16,9 @@
 "ey" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/template_noop)
 "eI" = (
 /obj/structure/cable,
@@ -174,7 +176,9 @@
 /area/ruin/unpowered)
 "xE" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/template_noop)
 "Af" = (
 /turf/template_noop,
@@ -305,7 +309,9 @@
 "SK" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/rust,
+/turf/open/floor/plating/rust{
+	initial_gas_mix = "PLANETARY_ATMOS"
+	},
 /area/template_noop)
 "TR" = (
 /obj/structure/cable,


### PR DESCRIPTION

## Changelog
:cl:
fix: 3.6 Seconds is no longer wasted roundstart.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
